### PR TITLE
move barrier to before saving checkpoint to reduce timeouts when saving

### DIFF
--- a/prismatic/training/strategies/base_strategy.py
+++ b/prismatic/training/strategies/base_strategy.py
@@ -224,8 +224,8 @@ class TrainingStrategy(ABC):
 
                         # Check for Termination & Save Final Checkpoint (in case `max_steps` is not None)
                         if self.max_steps is not None and metrics.global_step >= self.max_steps:
-                            self.save_checkpoint(metrics.run_dir, metrics.global_step, epoch, loss.item())
                             dist.barrier()
+                            self.save_checkpoint(metrics.run_dir, metrics.global_step, epoch, loss.item())
 
                             return
 
@@ -235,5 +235,5 @@ class TrainingStrategy(ABC):
 
             # Save checkpoint at end each epoch (if `self.max_steps` is None)
             if self.max_steps is None:
-                self.save_checkpoint(metrics.run_dir, metrics.global_step, epoch, loss.item())
                 dist.barrier()
+                self.save_checkpoint(metrics.run_dir, metrics.global_step, epoch, loss.item())

--- a/prismatic/training/strategies/fsdp.py
+++ b/prismatic/training/strategies/fsdp.py
@@ -115,6 +115,7 @@ class FSDPStrategy(TrainingStrategy):
                     if key.startswith(mprefix := f"{mkey}."):
                         model_state_dicts[mkey][key.removeprefix(mprefix)] = param
 
+            torch.barrier()
             # Save on rank zero *only*
             if overwatch.is_rank_zero():
                 checkpoint_dir = run_dir / "checkpoints"


### PR DESCRIPTION
Discussed this offline previously. After more extensive usage with this change, I've found that checkpoints still save properly, and barrier timeouts during saving happen much less often (have not had one in the past ~2 months).